### PR TITLE
Fixed the Second Empty Update Bug

### DIFF
--- a/taskbot.py
+++ b/taskbot.py
@@ -463,7 +463,8 @@ def handle_updates(updates):
             send_message(HELP, chat)
 
         else:
-            send_message("I'm sorry " + str(message['chat']['first_name']) + ". I'm afraid I can't do that.", chat)
+            send_message("I'm sorry " + str(message['chat']['first_name']) +
+                         ". I'm afraid I can't do that.", chat)
 
 
 def main():
@@ -474,7 +475,7 @@ def main():
         print("Updates")
         updates = get_updates(last_update_id)
 
-        if updates["result"] != "":
+        if updates["result"]:
             last_update_id = get_last_update_id(updates) + 1
             handle_updates(updates)
 


### PR DESCRIPTION
## Resolves #15 

The bug was caused by a mistake at line 477:
```python
if updates["result"] != "":
```
`updates` refers to a tuple which may be with the messages information. The original code was
```python
if len(updates["result"]) > 0:
```
This is considered wrong by the PEP8 style guide (used by pylint) and was incorrectly corrected in the style maintenance. `updates["result"]` is not equal to an empty string when the user doesn't send a message. For this reason, the code still sending `updates` to the rest of the code when eventually it will crash because of the empty variable.

The appropriate correction is:
```python
if updates["result"]:
```
This will check property if the `updates["result"]` is empty and will not execute de `if:` block if it is.
